### PR TITLE
nrf_modem: make IRQ priorities ZLI compatible

### DIFF
--- a/nrf_modem/include/nrf_modem_platform.h
+++ b/nrf_modem/include/nrf_modem_platform.h
@@ -35,13 +35,13 @@ extern "C" {
 #define NRF_MODEM_NETWORK_IRQ IPC_IRQn
 
 /**@brief Interrupt priority used on interrupt for communication with the network layer. */
-#define NRF_MODEM_NETWORK_IRQ_PRIORITY 0
+#define NRF_MODEM_NETWORK_IRQ_PRIORITY 1
 
 /**@brief Interrupt used for communication with the application layer. */
 #define NRF_MODEM_APPLICATION_IRQ EGU1_IRQn
 
 /**@brief Interrupt priority used on interrupt for communication with the application layer. */
-#define NRF_MODEM_APPLICATION_IRQ_PRIORITY 6
+#define NRF_MODEM_APPLICATION_IRQ_PRIORITY 4
 
 /**@} */
 


### PR DESCRIPTION
When zero-latency-interrupts are enabled, the previous  values for the
interrupt priority fail during IRQ initialization. The new values are
selected so that applications start without an assert from the irq system.

Signed-off-by: Sven Hädrich <sven.haedrich@grandcentrix.net>